### PR TITLE
Add c99 cflags

### DIFF
--- a/components/adminTool/Component.cdef
+++ b/components/adminTool/Component.cdef
@@ -29,4 +29,5 @@ requires:
 cflags:
 {
     -I$CURDIR/../json
+    -std=c99
 }


### PR DESCRIPTION
tool.c uses c99 style for loop declaration.
To avoid compile errors with a strict check option,
c99 option should be used.