### PR TITLE
add provides/headerDir in periodicSensor CDEF

### DIFF
--- a/components/periodicSensor/Component.cdef
+++ b/components/periodicSensor/Component.cdef
@@ -12,6 +12,14 @@ cflags:
     -std=c99
 }
 
+provides:
+{
+    headerDir:
+    {
+        ${CURDIR}
+    }
+}
+
 requires:
 {
     api:

--- a/test/sensor/Component.cdef
+++ b/test/sensor/Component.cdef
@@ -11,11 +11,6 @@ sources:
     sensor.c
 }
 
-cflags:
-{
-    -I${CURDIR}/../../components/periodicSensor/
-}
-
 requires:
 {
     component:


### PR DESCRIPTION
Specifying provides/headerDir in the CDEF means that clients don't have to add -I CFLAGS to access the necessary header.